### PR TITLE
25-bug-build-fails-after-adding-html-to-override-default-behavior

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,7 +16,7 @@ nav:
 
 theme:
   name: material
-  custom_dir: docs/overrides # - allows use of the uverride/main.html file
+  custom_dir: overrides # - allows use of the override/main.html file
   favicon: images/favicon.png
   logo: images/logo.png
   features:


### PR DESCRIPTION
Closes issue #25 

Works on my machine:

```
(venv) execution-spec % mkdocs serve
ERROR   -  Config value 'theme': The path set in custom_dir ('/Users/galassiae/Projects/execution-spec/docs/overrides') does not exist.

Aborted with a configuration error!
(venv) execution-spec % ls
BIDS_logo			LICENSE				md_link_check_config.json	npm-requirements.txt		requirements.txt		tools
CITATION.cff			README.md			mkdocs.yml			overrides			src				venv
(venv) execution-spec % vim mkdocs.yml 
(venv) execution-spec % mkdocs serve  
INFO    -  Building documentation...
INFO    -  Cleaning site directory
INFO    -  The following pages exist in the docs directory, but are not included in the "nav" configuration:
             - index.md
INFO    -  Doc file 'scope.md' contains a link './CHANGELOG.md#0.1.0.dev', but the doc 'CHANGELOG.md' does not contain an anchor '#0.1.0.dev'.
INFO    -  Documentation built in 0.23 seconds
INFO    -  [15:30:28] Watching paths for changes: 'src', 'mkdocs.yml'
INFO    -  [15:30:28] Serving on http://127.0.0.1:8000/execution-spec/
WARNING -  [15:30:39] "GET / HTTP/1.1" code 302
INFO    -  [15:30:39] Browser connected: http://localhost:8000/execution-spec/
^CINFO    -  Shutting down...
(venv) execution-spec % git status
On branch 25-bug-build-fails-after-adding-html-to-override-default-behavior
Your branch is up to date with 'origin/25-bug-build-fails-after-adding-html-to-override-default-behavior'.
```

Will close an merge as there's no CI check ATM.